### PR TITLE
Change config records into classes to run on 1.19

### DIFF
--- a/src/main/java/io/github/maxencedc/sparsestructures/CustomSpreadFactors.java
+++ b/src/main/java/io/github/maxencedc/sparsestructures/CustomSpreadFactors.java
@@ -1,0 +1,23 @@
+package io.github.maxencedc.sparsestructures;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class CustomSpreadFactors {
+    public String structure;
+    public double factor;
+
+    public CustomSpreadFactors(String structure, double factor) {
+        this.structure = structure;
+        this.factor = factor;
+    }
+
+    public String structure() {
+        return this.structure;
+    }
+
+    public double factor() {
+        return this.factor;
+    }
+}

--- a/src/main/java/io/github/maxencedc/sparsestructures/SparseStructuresConfig.java
+++ b/src/main/java/io/github/maxencedc/sparsestructures/SparseStructuresConfig.java
@@ -4,6 +4,14 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public record SparseStructuresConfig(double spreadFactor, List<customSpreadFactors> customSpreadFactors) {
-    public record customSpreadFactors(String structure, double factor) {}
+public class SparseStructuresConfig {
+    public double spreadFactor;
+    public double spreadFactor() { return this.spreadFactor; }
+    public List<CustomSpreadFactors> customSpreadFactors;
+    public List<CustomSpreadFactors> customSpreadFactors() { return this.customSpreadFactors; }
+    public SparseStructuresConfig(double spreadFactor, List<CustomSpreadFactors> customSpreadFactors)
+    {
+        this.spreadFactor = spreadFactor;
+        this.customSpreadFactors = customSpreadFactors;
+    }
 }

--- a/src/main/java/io/github/maxencedc/sparsestructures/mixins/SparseStructuresRegistryLoaderMixin.java
+++ b/src/main/java/io/github/maxencedc/sparsestructures/mixins/SparseStructuresRegistryLoaderMixin.java
@@ -2,6 +2,7 @@ package io.github.maxencedc.sparsestructures.mixins;
 
 import com.google.gson.JsonElement;
 import com.mojang.serialization.Decoder;
+import io.github.maxencedc.sparsestructures.CustomSpreadFactors;
 import io.github.maxencedc.sparsestructures.SparseStructures;
 import io.github.maxencedc.sparsestructures.SparseStructuresConfig;
 import net.minecraft.registry.*;
@@ -30,7 +31,7 @@ public abstract class SparseStructuresRegistryLoaderMixin {
                 if (s == null) return false;
                 String structure_set = registryKey.getValue().toString();
                 return structure_set.equals(s.structure()) || jsonElement.getAsJsonObject().getAsJsonArray("structures").asList().stream().anyMatch(p -> p.getAsJsonObject().get("structure").getAsString().equals(s.structure()));
-            }).findFirst().orElse(new SparseStructuresConfig.customSpreadFactors("", SparseStructures.config.spreadFactor())).factor();
+            }).findFirst().orElse(new CustomSpreadFactors("", SparseStructures.config.spreadFactor())).factor();
             int spacing = (int)(jsonElement.getAsJsonObject().getAsJsonObject("placement").get("spacing").getAsDouble() * factor);
             int separation = (int)(jsonElement.getAsJsonObject().getAsJsonObject("placement").get("separation").getAsDouble() * factor);
             if (separation >= spacing) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,6 +36,6 @@
   },
 
   "depends": {
-    "minecraft": "1.20.x"
+    "minecraft": "1.19.x"
   }
 }


### PR DESCRIPTION
The changes here will allow version 2.0 to run on 1.19.2

I'm not a Java developer, I'm not a minecraft modder, so I have no idea _why_ any of this works, or what the idiomatic way of turning a record with 'final' properties into a class with fully functional getter/setter is.

But hey, free code! :)