### PR TITLE
Port to 1.20.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://modmuss50.me/fabric.html
-	minecraft_version=1.20.1
-	yarn_mappings=1.20.1+build.10
-	loader_version=0.15.3
+    minecraft_version=1.20.6
+    yarn_mappings=1.20.6+build.1
+    loader_version=0.15.11
 
 # Mod Properties
 	mod_version = 2.1.1
@@ -14,4 +14,4 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# check this on https://modmuss50.me/fabric.html
-	fabric_version=0.91.0+1.20.1
+    fabric_version=0.98.0+1.20.6

--- a/src/main/java/io/github/maxencedc/sparsestructures/mixins/SparseStructuresRegistryLoaderMixin.java
+++ b/src/main/java/io/github/maxencedc/sparsestructures/mixins/SparseStructuresRegistryLoaderMixin.java
@@ -5,10 +5,8 @@ import com.mojang.serialization.Decoder;
 import io.github.maxencedc.sparsestructures.CustomSpreadFactors;
 import io.github.maxencedc.sparsestructures.SparseStructures;
 import net.minecraft.registry.*;
+import net.minecraft.registry.entry.RegistryEntryInfo;
 import net.minecraft.resource.Resource;
-import net.minecraft.resource.ResourceFinder;
-import net.minecraft.resource.ResourceManager;
-import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -16,14 +14,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.io.Reader;
-import java.util.Iterator;
-import java.util.Map;
 
 @Mixin(RegistryLoader.class)
 public abstract class SparseStructuresRegistryLoaderMixin {
 
-    @Inject(at = @At(value = "INVOKE", target = "Lcom/mojang/serialization/Decoder;parse(Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;"), method = "load(Lnet/minecraft/registry/RegistryOps$RegistryInfoGetter;Lnet/minecraft/resource/ResourceManager;Lnet/minecraft/registry/RegistryKey;Lnet/minecraft/registry/MutableRegistry;Lcom/mojang/serialization/Decoder;Ljava/util/Map;)V", locals = LocalCapture.CAPTURE_FAILHARD)
-    private static <E> void load(RegistryOps.RegistryInfoGetter registryInfoGetter, ResourceManager resourceManager, RegistryKey<? extends Registry<E>> registryRef, MutableRegistry<E> newRegistry, Decoder<E> decoder, Map<RegistryKey<?>, Exception> exceptions, CallbackInfo ci, String string, ResourceFinder resourceFinder, RegistryOps registryOps, Iterator var9, Map.Entry entry, Identifier identifier, RegistryKey registryKey, Resource resource, Reader reader, JsonElement jsonElement) {
+    @Inject(at = @At(value = "INVOKE", target = "Lcom/mojang/serialization/Decoder;parse(Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;"), method = "parseAndAdd(Lnet/minecraft/registry/MutableRegistry;Lcom/mojang/serialization/Decoder;Lnet/minecraft/registry/RegistryOps;Lnet/minecraft/registry/RegistryKey;Lnet/minecraft/resource/Resource;Lnet/minecraft/registry/entry/RegistryEntryInfo;)V", locals = LocalCapture.CAPTURE_FAILHARD)
+    private static <E> void load(MutableRegistry<E> registry, Decoder<E> decoder, RegistryOps<JsonElement> ops, RegistryKey<E> registryKey, Resource resource, RegistryEntryInfo entryInfo, CallbackInfo ci, Reader reader, JsonElement jsonElement) {
+
+        String string = registry.getKey().getValue().getPath();
+
         if (string.equals("worldgen/structure_set") && !jsonElement.getAsJsonObject().getAsJsonObject("placement").get("type").getAsString().equals("minecraft:concentric_rings")) {
             double factor = SparseStructures.config.customSpreadFactors().stream().filter(s -> {
                 if (s == null) return false;


### PR DESCRIPTION
This is a port to 1.20.6

1.20.6 split the `load` function into `loadFromResource` and `loadFromNetwork` (in `net.minecraft.registry.RegistryLoader`)

I've changed the mixin to inject into the `net.minecraft.registry.RegistryLoader.parseAndAdd` function since both of the two methods use it.

On another note, it looks like 2.1.2 was released, but `gradle.properties` still says 2.1.1?