### PR TITLE
Fix #65

### DIFF
--- a/fabric/src/main/java/io/github/maxencedc/sparsestructures/mixin/MakeStructuresSparseFabric.java
+++ b/fabric/src/main/java/io/github/maxencedc/sparsestructures/mixin/MakeStructuresSparseFabric.java
@@ -23,7 +23,7 @@ import java.io.Reader;
 @Mixin(targets = "net.minecraft.resources.RegistryLoadTask$PendingRegistration")
 public class MakeStructuresSparseFabric {
 
-    @Inject(at = @At(value = "INVOKE", target = "Lcom/mojang/serialization/DataResult;getOrThrow()Ljava/lang/Object;"), method = "loadFromResource")
+    @Inject(at = @At(value = "INVOKE", target = "Lcom/mojang/serialization/Decoder;parse(Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;"), method = "loadFromResource")
     private static <T> void loadFromResource(Decoder<T> elementDecoder, RegistryOps<JsonElement> ops, ResourceKey<T> elementKey, Resource thunk, CallbackInfoReturnable<Either<T, Exception>> cir, @Local(name = "json") JsonElement json) {
         String string = elementKey.registryKey().identifier().getPath();
         if (!string.equals("worldgen/structure_set")) return;


### PR DESCRIPTION
Simply changes the injection point from `getOrThrow()` (after deserialise) to `parse(ops, json)` (before deserialize) to bring it in line with how the neoforge version of the same mixin is functioning. This change is in accordance with my explanation (quoted below):

> Heyo. I went and looked at the code (and I was the one that mentioned the obfuscated mixin but had intended that idea to be discarded). The _actual_ problem is because of this mixing over here:
> 
> https://github.com/MaxenceDC/sparsestructures/blob/26.1/fabric/src/main/java/io/github/maxencedc/sparsestructures/mixin/MakeStructuresSparseFabric.java
> 
> The injection point is wrong. It's put on the `getOrThrow` which comes after deserialization. So all you would need to do is change the injection point to this:
> 
> ```
> @Inject(at = @At(
>                value = "INVOKE",
>                target = "Lcom/mojang/serialization/Decoder;parse(Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;"),
>            method = "loadFromResource")
> ```
> 
> The neoforge one is already correct and targets the parse call, so it is only the fabric version that is broken.

